### PR TITLE
Allocate security group / toggle using EC2's private or public to SSH / enable use of python3 if installed (e.g. Ubuntu 22)

### DIFF
--- a/ansible/strongswan-install.yml
+++ b/ansible/strongswan-install.yml
@@ -22,6 +22,7 @@
     raw: >
       test -e /usr/bin/python ||
       (
+        (test -e /usr/bin/python3 && ln -s /usr/bin/python3 /usr/bin/python) || 
         (test -e /usr/bin/apt-get && (apt-get -y update && apt-get install -y python)) ||
         (test -e /usr/bin/yum && (yum makecache fast && yum install -y python))
       )

--- a/main.tf
+++ b/main.tf
@@ -66,12 +66,16 @@ resource "aws_instance" "vpn_server" {
 # https://wiki.strongswan.org/projects/strongswan/wiki/connsection
 # https://www.cisco.com/c/en/us/support/docs/ip/internet-key-exchange-ike/117258-config-l2l.html
 #
+
+locals {
+  host_ip = var.ssh_public == true ? aws_instance.vpn_server.public_ip : aws_instance.vpn_server.private_ip
+}
 module "ansible_provisioner" {
   source = "github.com/cloudposse/tf_ansible"
 
   arguments = ["--ssh-common-args='-o StrictHostKeyChecking=no' --user=${var.username} --private-key ${var.private_key}"]
   envs = [
-    "host=${aws_instance.vpn_server.public_ip}",
+    "host=${local.host_ip}",
     "module_path=${path.module}",
     "client_ip=${var.client_ip}",
     "client_cidr=${var.client_cidr}",

--- a/main.tf
+++ b/main.tf
@@ -20,36 +20,6 @@ data "aws_vpc" "selected" {
   id = var.vpc_id
 }
 
-# TODO: change this to something more secure!
-# It is wide open now for testing purposes
-resource "aws_security_group" "allow_vpn" {
-  name        = "allow_all"
-  description = "Allows all incoming and outgoing traffic (INSECURE)"
-  vpc_id      = var.vpc_id
-
-  ingress {
-    description      = "Allow all incomming traffic"
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
-
-  egress {
-    description      = "Allow all outgoing traffic"
-    from_port        = 0
-    to_port          = 0
-    protocol         = "-1"
-    cidr_blocks      = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
-
-  tags = {
-    Name = "allow_all"
-  }
-}
-
 data "aws_key_pair" "vpn" {
   key_name = var.key_pair
 }
@@ -74,7 +44,7 @@ resource "aws_instance" "vpn_server" {
   # This needs to be off or the instance won't work as a router
   source_dest_check = false
 
-  vpc_security_group_ids = [aws_security_group.allow_vpn.id]
+  vpc_security_group_ids = [var.sg_id]
 
   tags = {
     Name = var.name

--- a/variables.tf
+++ b/variables.tf
@@ -28,6 +28,12 @@ variable "subnet_id" {
   description = "The ID of the subnet where the instance will be located"
 }
 
+variable "ssh_public" {
+  type        = bool
+  description = "Use the public IP to SSH - if not the private - default is false"
+  default     = false
+}
+
 # Security
 variable "key_pair" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,11 @@ variable "username" {
   description = "The user to use when connecting to the EC2 instance (Ansible provisioning)"
 }
 
+variable "sg_id" {
+  type        = string
+  description = "The ID of the sg applied to the instance"
+}
+
 # VPN endpoint(s) configuration
 variable "client_ip" {
   type        = string


### PR DESCRIPTION
Allocate security group / toggle using EC2's private or public to SSH / enable use of python3 if installed (e.g. Ubuntu 22)

all these things are minor changes to make it more flexible and more secure (no more "ALL open SG" created - down to implementer to create an SG with approrpriate ports open for StrongSwan and whatever else is needed in their environment (SSH/monitoring ports etc etc)